### PR TITLE
Add a IIR low pass filter to simulated barometer values

### DIFF
--- a/galadriel/src/lib.rs
+++ b/galadriel/src/lib.rs
@@ -76,6 +76,7 @@ pub struct Simulation {
     settings: SimulationSettings,
     pub rocket: Rocket,
     pub state: SimulationState,
+    last_sensor_values: Option<SensorData>,
 }
 
 impl Simulation {
@@ -100,6 +101,7 @@ impl Simulation {
             settings: settings.clone(),
             rocket,
             state,
+            last_sensor_values: None,
         }
     }
 
@@ -217,7 +219,9 @@ impl Simulation {
     }
 
     pub fn sensors(&mut self) -> SensorData {
-        SensorData::sample(&mut self.rng, &self.state, &self.settings)
+        let new = SensorData::sample(&mut self.rng, &self.state, &self.settings, self.last_sensor_values.as_ref());
+        self.last_sensor_values = Some(new.clone());
+        new
     }
 }
 

--- a/galadriel/src/replication.rs
+++ b/galadriel/src/replication.rs
@@ -40,6 +40,7 @@ impl Iterator for Replication {
                 accelerometer1: next.accelerometer1,
                 accelerometer2: next.accelerometer2,
                 magnetometer: next.magnetometer,
+                lp_filtered_pressure: next.pressure,
                 pressure: next.pressure,
             }
         } else {
@@ -52,6 +53,7 @@ impl Iterator for Replication {
                 accelerometer1: last.accelerometer1.zip(next.accelerometer1).map(|(l, n)| l.lerp(&n, t)),
                 accelerometer2: last.accelerometer2.zip(next.accelerometer2).map(|(l, n)| l.lerp(&n, t)),
                 magnetometer: last.magnetometer.zip(next.magnetometer).map(|(l, n)| l.lerp(&n, t)),
+                lp_filtered_pressure: next.pressure,
                 pressure: last.pressure.zip(next.pressure).map(|(l, n)| l + (n - l)*t),
             }
             // TODO: linear interpolation is probably not the best choice here.

--- a/gui/src/data_source/simulation.rs
+++ b/gui/src/data_source/simulation.rs
@@ -66,6 +66,7 @@ impl StateSimulation for VehicleState {
             accelerometer1: self.accelerometer1,
             accelerometer2: self.accelerometer2,
             magnetometer: self.magnetometer,
+            lp_filtered_pressure: self.pressure_baro,
             pressure: self.pressure_baro,
         }
     }


### PR DESCRIPTION
Low-pass filtering the barometer simulates an inadequately vented avionics bay that lags behind at high speeds.

Extreme example showing delayed barometer values and effect on speed estimation and apogee prediction:

![Screenshot_20240611_235314](https://github.com/tudsat-rocket/sam/assets/2438809/542df670-843c-466e-ae8a-d094290973cc)
