### PR TITLE
Add shared CAN message types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4287,6 +4287,7 @@ dependencies = [
 name = "shared_types"
 version = "0.1.0"
 dependencies = [
+ "crc",
  "nalgebra",
  "postcard",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde = { version = "1", default-features = false, features = ["derive", "alloc"
 serde_json = "1.0.89"
 postcard = "1.0"
 siphasher = "0.3"
+crc = "2"
 # misc
 chrono = "0.4"
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -27,8 +27,8 @@ walkers = "0.22"
 serde = { workspace = true }
 serde_json = { workspace = true }
 postcard = { workspace = true }
+crc = { workspace = true }
 serialport = "4"
-crc = "2"
 # misc
 mint = { workspace = true }
 nalgebra = { workspace = true }

--- a/shared_types/Cargo.toml
+++ b/shared_types/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 nalgebra = { workspace = true }
+crc = { workspace = true }
 serde = { workspace = true }
 postcard = { workspace = true }
 siphasher = { workspace = true }

--- a/shared_types/src/can.rs
+++ b/shared_types/src/can.rs
@@ -1,0 +1,218 @@
+//! Data structures for messages sent via the rocket's internal CAN bus.
+//!
+//! Each message has a corresponding set of message IDs, which allow
+//! identifying the message and also encodes priority, with lower IDs
+//! being higher priority. General scheme:
+//!
+//! 0x000 - 0x0ff      Flight computer outputs (e.g. valve commands)
+//!     0x0i0 - 0x0if  IO board i (0..f)
+//!
+//! 0x100 - 0x1ff      Flight computer inputs (e.g. collected sensor data)
+//!     0x1i0 - 0x1af  IO board i (0..a)
+//!     0x1b0 - 0x1ef  Fins 1-4
+//!     0x1f0 - 0x1ff  Battery board telemetry
+//!
+//! 0x200 - 0x2ff      Internal telemetry (e.g. data shared with payloads)
+
+use crc::{Crc, CRC_16_IBM_SDLC};
+
+const CRC: Crc<u16> = Crc::<u16>::new(&CRC_16_IBM_SDLC); // TODO: X-25?
+
+pub enum IoBoardRole {
+    Acs = 1,
+    Recovery = 2,
+    Payload = 8,
+}
+
+pub enum CanBusMessageId {
+    IoBoardCommand(IoBoardRole, u8),
+    IoBoardInput(IoBoardRole, u8),
+    FinBoardInput(u8, u8),
+    BatteryBoardInput(u8),
+    TelemetryBroadcast(u8),
+}
+
+impl Into<u16> for CanBusMessageId {
+    fn into(self) -> u16 {
+        match self {
+            Self::IoBoardCommand(role, id) => 0x000 + (role as u16 & 0x0f) << 4 + (id & 0x0f),
+            Self::IoBoardInput(role, id)   => 0x100 + (role as u16 & 0x0f) << 4 + (id & 0x0f),
+            Self::FinBoardInput(fin, id)   => 0x1f0 + ((fin + 0x0b) as u16 & 0x0f) << 4 + (id & 0x0f),
+            Self::BatteryBoardInput(id)    => 0x1f0 + (id as u16 & 0x0f),
+            Self::TelemetryBroadcast(id)   => 0x200 + id as u16,
+        }
+    }
+}
+
+impl TryFrom<u16> for CanBusMessageId {
+    type Error = u16;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            0x000..=0x0ff => {
+                let role_id: u8 = ((value & 0x0f0) >> 4) as u8;
+                let Ok(role) = IoBoardRole::try_from(role_id) else { return Err(value) };
+                Ok(Self::IoBoardCommand(role, (value & 0x00f) as u8))
+            },
+            0x100..=0x1af => {
+                let role_id: u8 = ((value & 0x0f0) >> 4) as u8;
+                let Ok(role) = IoBoardRole::try_from(role_id) else { return Err(value) };
+                Ok(Self::IoBoardInput(role, (value & 0x00f) as u8))
+            },
+            0x1b0..=0x1ef => {
+                let fin_id: u8 = ((value & 0x0f0) >> 4) as u8 - 0x0b;
+                Ok(Self::FinBoardInput(fin_id, (value & 0x00f) as u8))
+            },
+            0x1f0..=0x1ff => Ok(Self::BatteryBoardInput((value & 0x00f) as u8)),
+            0x200..=0x2ff => Ok(Self::TelemetryBroadcast((value & 0x0ff) as u8)),
+            unknown => Err(unknown)
+        }
+    }
+}
+
+pub trait CanBusMessage: Sized {
+    fn serialize(self) -> [u8; 6];
+    fn deserialize(data: &[u8]) -> Option<Self>;
+
+    fn parse(data: [u8; 8]) -> Result<Option<Self>, ()> {
+        let crc_test = u16::from_le_bytes([data[6], data[7]]);
+        let crc_ref = CRC.checksum(&data[..6]);
+        if crc_test != crc_ref {
+            return Err(());
+        }
+
+        Ok(Self::deserialize(&data[..6]))
+    }
+}
+
+impl TryFrom<u8> for IoBoardRole {
+    type Error = u8;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(IoBoardRole::Acs),
+            2 => Ok(IoBoardRole::Recovery),
+            8 => Ok(IoBoardRole::Payload),
+            _ => Err(value)
+        }
+    }
+}
+
+pub struct IoBoardOutputMessage {
+    pub outputs: [bool; 8],
+    // TODO: max high duration, failsafe value?
+}
+
+impl CanBusMessage for IoBoardOutputMessage {
+    fn serialize(self) -> [u8; 6] {
+        let byte = self.outputs.iter().enumerate()
+            .map(|(i, output)| (*output as u8) << (7-i))
+            .reduce(|a, b| a | b)
+            .unwrap();
+
+        [byte, byte, byte, byte, 0x00, 0x00]
+    }
+
+    fn deserialize(data: &[u8]) -> Option<Self> {
+        let byte = data[0]; // TODO
+
+        Some(Self {
+            outputs: [
+                byte & 0b1000_0000 > 0,
+                byte & 0b0100_0000 > 0,
+                byte & 0b0010_0000 > 0,
+                byte & 0b0001_0000 > 0,
+                byte & 0b0000_1000 > 0,
+                byte & 0b0000_0100 > 0,
+                byte & 0b0000_0010 > 0,
+                byte & 0b0000_0001 > 0,
+            ],
+        })
+    }
+}
+
+pub struct IoBoardSensorMessage {
+    pub sensors: [u16; 3],
+}
+
+impl CanBusMessage for IoBoardSensorMessage {
+    fn serialize(self) -> [u8; 6] {
+        let mut msg = [0x00; 6];
+        msg[0..2].copy_from_slice(&self.sensors[0].to_be_bytes());
+        msg[2..4].copy_from_slice(&self.sensors[1].to_be_bytes());
+        msg[4..6].copy_from_slice(&self.sensors[2].to_be_bytes());
+        msg
+    }
+
+    fn deserialize(data: &[u8]) -> Option<Self> {
+        Some(Self {
+            sensors: [
+                u16::from_be_bytes([data[0], data[1]]),
+                u16::from_be_bytes([data[2], data[3]]),
+                u16::from_be_bytes([data[4], data[5]]),
+            ]
+        })
+    }
+}
+
+// Format defined in Payload Specification, do not change.
+pub struct TelemetryToPayloadMessage {
+    pub time: u32,
+    pub mode: crate::FlightMode,
+    pub altitude: u16,
+}
+
+impl CanBusMessage for TelemetryToPayloadMessage {
+    fn serialize(self) -> [u8; 6] {
+        let mut msg = [0x00; 6];
+        msg[0..3].copy_from_slice(&self.time.to_le_bytes()[..3]);
+        msg[3] = self.mode as u8;
+        msg[4..6].copy_from_slice(&self.altitude.to_be_bytes());
+        msg
+    }
+
+    fn deserialize(data: &[u8]) -> Option<Self> {
+        let time = u32::from_le_bytes([data[0], data[1], data[2], 0x00]);
+        let Ok(mode) = data[3].try_into() else { return None };
+        let altitude = u16::from_le_bytes([data[4], data[5]]);
+
+        Some(Self {
+                time,
+                mode,
+                altitude
+        })
+    }
+}
+
+pub struct BatteryTelemetryMessage {
+    pub voltage_battery: u16, // mV
+    pub voltage_charge: u16, // mV
+    pub current: u16, // mA
+    pub stat0: bool, // TODO: higher type
+    pub stat1: bool,
+}
+
+impl CanBusMessage for BatteryTelemetryMessage {
+    fn serialize(self) -> [u8; 6] {
+        let mut msg = [0x00; 6];
+        let vb = (self.voltage_battery << 1) | (self.stat0 as u16);
+        let vc = (self.voltage_charge << 1) | (self.stat1 as u16);
+        msg[0..2].copy_from_slice(&vb.to_be_bytes());
+        msg[2..4].copy_from_slice(&vc.to_be_bytes());
+        msg[4..6].copy_from_slice(&self.current.to_be_bytes());
+        msg
+    }
+
+    fn deserialize(data: &[u8]) -> Option<Self> {
+        let vb = u16::from_be_bytes([data[0], data[1]]);
+        let vc = u16::from_be_bytes([data[2], data[3]]);
+        let current = u16::from_be_bytes([data[4], data[5]]);
+        Some(Self {
+            voltage_battery: vb >> 1,
+            voltage_charge: vc >> 1,
+            current,
+            stat0: (vb & 0b1) > 0,
+            stat1: (vc & 0b1) > 0,
+        })
+    }
+}

--- a/shared_types/src/lib.rs
+++ b/shared_types/src/lib.rs
@@ -3,8 +3,11 @@
 #[cfg(target_os = "none")]
 extern crate alloc;
 
-pub mod settings;
-pub mod telemetry;
+pub mod can;
+pub use can::*;
 
+pub mod settings;
 pub use settings::*;
+
+pub mod telemetry;
 pub use telemetry::*;

--- a/shared_types/src/telemetry.rs
+++ b/shared_types/src/telemetry.rs
@@ -95,6 +95,24 @@ pub enum FlightMode {
     Landed = 7,
 }
 
+impl TryFrom<u8> for FlightMode {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Idle),
+            1 => Ok(Self::HardwareArmed),
+            2 => Ok(Self::Armed),
+            3 => Ok(Self::Burn),
+            4 => Ok(Self::Coast),
+            5 => Ok(Self::RecoveryDrogue),
+            6 => Ok(Self::RecoveryMain),
+            7 => Ok(Self::Landed),
+            _ => Err(())
+        }
+    }
+}
+
 impl FlightMode {
     pub fn led_state(self, time: u32) -> (bool, bool, bool) {
         match self {
@@ -413,6 +431,7 @@ impl From<VehicleState> for TelemetryMainCompressed {
     }
 }
 
+#[cfg(not(target_os = "none"))]
 impl Into<VehicleState> for TelemetryMainCompressed {
     fn into(self) -> VehicleState {
         let (x, y, z, w) = self.orientation;
@@ -720,6 +739,7 @@ impl DownlinkMessage {
     }
 }
 
+#[cfg(not(target_os = "none"))]
 impl From<DownlinkMessage> for VehicleState {
     fn from(msg: DownlinkMessage) -> VehicleState {
         match msg {


### PR DESCRIPTION
Include CAN message definitions in `shared_types`. Not used in sam itself, but shared by firmware implementations. Could potentially be moved somewhere else in the future.